### PR TITLE
feat(landing): Add page transition

### DIFF
--- a/src/features/landing/Container.tsx
+++ b/src/features/landing/Container.tsx
@@ -3,15 +3,24 @@ import { FunctionComponent, useState } from 'react';
 import BackgroundGraphicSvg from '~/features/landing/components/svg/BackgroundGraphicSvg';
 import ScrollToEnter from '~/features/landing/components/ScrollToEnter';
 import ExpandableCircle from '~/features/landing/components/ExpandableCircle';
+import { LANDING_LAST_ANIMATION_NAME } from '~/features/landing/constants';
 
 const LandingContainer: FunctionComponent = () => {
-  const [active, setActive] = useState(false);
+  const [canMoveNext, setCanMoveNext] = useState(false);
+  const [isTriggeredTransition, setTriggeredTransition] = useState(false);
+
   return (
-    <div className="landing-container" onClick={() => setActive(true)}>
+    <div
+      className="landing-container"
+      onAnimationEnd={({ animationName }) => {
+        if (animationName === LANDING_LAST_ANIMATION_NAME) setCanMoveNext(true);
+      }}
+      onWheel={() => canMoveNext && setTriggeredTransition(true)}
+    >
       <BackgroundGraphicSvg />
       <h1 className="landing-title">Jjin-Nolsa</h1>
       <ScrollToEnter />
-      <ExpandableCircle expand={active} />
+      <ExpandableCircle expand={isTriggeredTransition} />
     </div>
   );
 };

--- a/src/features/landing/Container.tsx
+++ b/src/features/landing/Container.tsx
@@ -1,20 +1,17 @@
-import { FunctionComponent } from 'react';
+import { FunctionComponent, useState } from 'react';
 
 import BackgroundGraphicSvg from '~/features/landing/components/svg/BackgroundGraphicSvg';
 import ScrollToEnter from '~/features/landing/components/ScrollToEnter';
+import ExpandableCircle from '~/features/landing/components/ExpandableCircle';
 
-/**
- * < onload >
- * 1. bg - 밑에서 위로 올라오기
- * 2. title - 위에서 아래로 떨어지기 & 바운스
- * 3. scroll to enter - 밑에서 위로 올라오기 & 위 - 아래로 움직이기 Loop
- */
 const LandingContainer: FunctionComponent = () => {
+  const [active, setActive] = useState(false);
   return (
-    <div className="landing-container">
-      <h1 className="landing-title">Jjin-Nolsa</h1>
+    <div className="landing-container" onClick={() => setActive(true)}>
       <BackgroundGraphicSvg />
+      <h1 className="landing-title">Jjin-Nolsa</h1>
       <ScrollToEnter />
+      <ExpandableCircle expand={active} />
     </div>
   );
 };

--- a/src/features/landing/components/ExpandableCircle.tsx
+++ b/src/features/landing/components/ExpandableCircle.tsx
@@ -1,0 +1,9 @@
+import { FunctionComponent } from 'react';
+
+const ExpandableCircle: FunctionComponent<{ expand: boolean }> = ({
+  expand,
+}) => {
+  return <div className={`expandable-circle ${expand ? 'expand' : ''}`} />;
+};
+
+export default ExpandableCircle;

--- a/src/features/landing/constants.ts
+++ b/src/features/landing/constants.ts
@@ -1,0 +1,1 @@
+export const LANDING_LAST_ANIMATION_NAME = 'scroll-slide-top-in';

--- a/src/style/landing.scss
+++ b/src/style/landing.scss
@@ -35,10 +35,10 @@ $scroll-animation-delay: 0.3s + $bg-slide-animation-duration + $title-slide-anim
 }
 
 .landing-title {
+  position: relative;
   color: white;
   font-size: 25vw;
   text-align: center;
-  z-index: 1;
   animation:
     $title-animation-delay ease-out 0s 1 title-wait,
     $title-slide-animation-duration ease-in $title-animation-delay title-slide-top-in;
@@ -123,5 +123,22 @@ $scroll-animation-delay: 0.3s + $bg-slide-animation-duration + $title-slide-anim
 
   90% {
     bottom: 15px;
+  }
+}
+
+.expandable-circle {
+  background-color: #fac152;
+  width: 0;
+  height: 0;
+  border-radius: 50%;
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  transition: width 0.8s, height 0.8s;
+
+  &.expand {
+    width: max(150vw, 150vh);
+    height: max(150vw, 150vh);
   }
 }


### PR DESCRIPTION
## 🤩 개요
Landing에서 다음 페이지로 넘어갈 때 나타나는 페이지 전환 애니메이션 효과를 추가함

## 🧑‍💻 작업 사항
- scroll-to-enter가 올라오는 애니메이션이 끝나는 시점 이후에 휠을 돌리면 페이지 전환 효과 재생
- 원이 가운데에서부터 점점 커져서 페이지를 꽉 채우는 ExpandableCircle 컴포넌트 추가

## 📖 참고 사항

TODO
- 현재는 휠을 조금만 돌려도 페이지 전환 효과가 재생됨. 스크롤을 얼마나 내려야 다음 페이지로 이동하게 할 지 결정 필요
- 페이지 전환 애니메이션이 끝나면 Home으로 전환하는 부분 추가 필요

![ezgif com-video-to-gif (1)](https://user-images.githubusercontent.com/40057032/218149829-11e640b3-162b-4ea2-a6af-ed619fa9d8d3.gif)
