### PR TITLE
[Fix] vscode scss setting

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -10,5 +10,8 @@
   "editor.codeActionsOnSave": {
     "source.fixAll.stylelint": true
   },
-  "stylelint.validate": ["css", "scss"]
+  "stylelint.validate": ["css", "scss"],
+  "[scss]": {
+    "editor.defaultFormatter": "stylelint.vscode-stylelint"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "lint:prettier": "prettier --list-different \"src/**/*.{json,html}\"",
     "lint:type": "tsc --pretty",
     "lint:stylelint": "stylelint \"**/*.scss\"",
-    "stylelint:fix": "stylelint \"**/*.scss\" --fix",
+    "fix:stylelint": "stylelint \"**/*.scss\" --fix",
     "lint": "FORCE_COLOR=1 npm-run-all -p --print-label \"lint:**\"",
     "fix": "FORCE_COLOR=1 npm-run-all -p --print-label \"fix:**\"",
     "clean": "rm -rf ./node_modules ./dist",


### PR DESCRIPTION
## 💡 이슈
vscode에서 `sass formatter`와 `stylelint` extension이 서로 충돌함.

## 🤩 개요
scss vscode setting을 stylelint로 고정시킵니다.

## 🧑‍💻 작업 사항
`stylelint-config-prettier`라는 플러그인을 설치하여 몇 가지 충돌은 해결했지만 그래도 충돌이 남아 있어 앞으로도 규칙을 계속 추가해야 할 것 같다는 생각에 vscode setting을 stylelint로 고정시켰습니다.

## 📖 참고 사항
공유할 내용, 레퍼런스, 추가로 발생할 것으로 예상되는 이슈, 스크린샷 등을 넣어 주세요.
