### PR TITLE
[Feat] 이미지 cdn 서비스 사용하여 성능 개선

### DIFF
--- a/src/features/dailyBook/Container.tsx
+++ b/src/features/dailyBook/Container.tsx
@@ -5,6 +5,7 @@ import { PAGE_NAME } from '../shared/constants';
 import ScrollToEnter from '../landing/components/ScrollToEnter';
 import Floating from '../shared/components/Floating';
 import { AppData } from '../types';
+import Image from '../shared/components/Image';
 
 import ContentContainer from './components/Container';
 import DateDial from './components/DateDial';
@@ -43,7 +44,7 @@ const DailyBookContainer: FunctionComponent<DailyBookContainerProps> = ({
       {isDailyBook && (
         <>
           <Link to={`/detail/${activeIndex - 1}`} preventScrollReset>
-            <img
+            <Image
               className="dailybook-image-cover"
               src={data[activeIndex - 1].coverImage}
               alt="cover"
@@ -51,14 +52,14 @@ const DailyBookContainer: FunctionComponent<DailyBookContainerProps> = ({
               height={631}
             />
           </Link>
-          <img
+          <Image
             className="dailybook-image-cover-second"
             src={data[activeIndex % data.length].coverImage}
             alt="second cover"
             width={370}
             height={631}
           />
-          <img
+          <Image
             className="dailybook-image-cover-third"
             src={data[(activeIndex + 1) % data.length].coverImage}
             alt="second cover"

--- a/src/features/detail/components/CloseButton.tsx
+++ b/src/features/detail/components/CloseButton.tsx
@@ -1,12 +1,14 @@
 import { FunctionComponent } from 'react';
 
+import Image from '~/features/shared/components/Image';
+
 type Props = {
   onClick?: () => void;
 };
 const CloseButton: FunctionComponent<Props> = ({ onClick }) => {
   return (
     <button className="close-button" onClick={onClick}>
-      <img src="/svg/close.svg" />
+      <Image src="/svg/close.svg" alt="닫기 버튼" />
     </button>
   );
 };

--- a/src/features/detail/components/Cover.tsx
+++ b/src/features/detail/components/Cover.tsx
@@ -1,6 +1,7 @@
 import { FunctionComponent } from 'react';
 import { Link } from 'react-router-dom';
 
+import Image from '~/features/shared/components/Image';
 import CloseButton from '~/features/detail/components/CloseButton';
 
 type Props = {
@@ -23,14 +24,14 @@ const Cover: FunctionComponent<Props> = ({ bgColor, date, title, imgSrc }) => {
       <Link to="/" preventScrollReset>
         <CloseButton />
       </Link>
-      <img className="cover-image" src={imgSrc} alt={title} />
+      <Image className="cover-image" src={imgSrc} alt={title} />
       <div className="contents-wrapper">
         <div className="date" style={{ backgroundColor: bgColor }}>
           {date}
         </div>
         <h1 className="title">{title}</h1>
         <div className="scroll-down">
-          <img src="/svg/detail-scroll-down.svg" />
+          <Image src="/svg/detail-scroll-down.svg" alt="스크롤 다운 이미지" />
         </div>
       </div>
     </section>

--- a/src/features/detail/components/ImageModal.tsx
+++ b/src/features/detail/components/ImageModal.tsx
@@ -1,6 +1,7 @@
 import { FunctionComponent } from 'react';
 
 import CloseButton from '~/features/detail/components/CloseButton';
+import Image from '~/features/shared/components/Image';
 
 type Props = {
   show: boolean;
@@ -15,7 +16,7 @@ const ImageModal: FunctionComponent<Props> = ({ show, src, alt, onClose }) => {
       {show && (
         <div className="modal">
           <div className="image-wrapper">
-            <img src={src} alt={alt} />
+            <Image src={src} alt={alt} />
             <CloseButton onClick={onClose} />
           </div>
         </div>

--- a/src/features/detail/components/ImageSlider.tsx
+++ b/src/features/detail/components/ImageSlider.tsx
@@ -1,5 +1,7 @@
 import { FunctionComponent } from 'react';
 
+import Image from '~/features/shared/components/Image';
+
 type Props = {
   imgSrcs: string[];
   paused: boolean;
@@ -15,11 +17,12 @@ const ImageSlider: FunctionComponent<Props> = ({
 }) => {
   return (
     <div className={`image-slide ${direction} ${paused ? 'pause' : ''}`}>
-      {imgSrcs.map((src) => (
-        <img
+      {imgSrcs.map((src, idx) => (
+        <Image
           key={src}
           className="image-slide-element"
           src={src}
+          alt={`이미지 슬라이드 ${idx + 1}번째`}
           onClick={() => onClickImage(src)}
         />
       ))}

--- a/src/features/shared/components/Image/index.tsx
+++ b/src/features/shared/components/Image/index.tsx
@@ -3,13 +3,18 @@ import { forwardRef, LegacyRef } from 'react';
 import '~/style/index.scss';
 import { ImgProps } from '~/types';
 
-const Image = (props: ImgProps, ref: LegacyRef<HTMLImageElement> | null) => {
-  const { src, alt, width, height, className } = props;
+type Props = ImgProps & { onClick?: () => void };
+
+const Image = (props: Props, ref: LegacyRef<HTMLImageElement> | null) => {
+  const { src, alt, width, height, className, onClick } = props;
   const aspectRatio = width && height ? width / height : 0;
+  const srcWithSize = `${src}?w=${width}&h=${height}`;
   return (
     <img
-      {...{ className, src, alt, width, height, ref }}
+      {...{ className, alt, width, height, ref }}
+      src={srcWithSize}
       style={{ aspectRatio }}
+      onClick={onClick}
     />
   );
 };

--- a/src/features/shared/constants.ts
+++ b/src/features/shared/constants.ts
@@ -28,5 +28,7 @@ export const PAGE_NAME = {
   ABOUT: MAP_LENGTH - 1,
 };
 
-export const PHOTO_PATH_PREFIX =
+export const PREV_PHOTO_PATH_PREFIX =
   'https://raw.githubusercontent.com/Nexters/who-really-wants-to-play/images/images';
+
+export const PHOTO_PATH_PREFIX = 'https://jjinn-nolsa.imgix.net';


### PR DESCRIPTION
## 💡 이슈
resolve #{이슈번호}

## 🤩 개요
이미지 cdn 서비스 사용하여 성능 개선

## 🧑‍💻 작업 사항
### https://imgix.com/ 사용
1. 기존 깃헙 cdn주소를 입력
2. imgix에서 제공해주는 도메인 사용
3. w, h, crop 등 기능 사용 가능

### Image컴포넌트에 w, h 옵션 추가하여 이미지 요청

## 📖 참고 사항
### 사용 전
![스크린샷 2023-03-03 오후 10 52 13](https://user-images.githubusercontent.com/62797441/222740524-383cedc5-eab2-4c0d-a968-a796c7af730a.png)

![스크린샷 2023-03-03 오후 10 57 56](https://user-images.githubusercontent.com/62797441/222740900-91558ff2-519d-4cc4-841e-ebdca269dd66.png)

### 사용 후
![스크린샷 2023-03-03 오후 10 54 04](https://user-images.githubusercontent.com/62797441/222740825-ca1aeb1e-3367-4fe7-9294-e07b673a2d03.png)

![스크린샷 2023-03-03 오후 10 56 36](https://user-images.githubusercontent.com/62797441/222740788-4bd47e42-c631-4a5d-b143-1e12c4fc3021.png)

17.7MB -> 9.1MB, 6.23s -> 4.59s로 개선
