### PR TITLE
feat(detail): 디테일 -> 메인 이동 시 스크롤 기억하기

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,6 +7,7 @@ import AppContainer from './features/Container';
 import './style/index.scss';
 
 import DetailContainer from '~/features/detail/Container';
+import { YScrollProvider } from '~/features/shared/components/Context/YScrollContext';
 
 const App: FunctionComponent = () => {
   return <AppContainer />;
@@ -18,4 +19,8 @@ const router = createHashRouter([
 ]);
 
 const root = createRoot(document.getElementById('app') as Element);
-root.render(<RouterProvider router={router} />);
+root.render(
+  <YScrollProvider>
+    <RouterProvider router={router} />
+  </YScrollProvider>,
+);

--- a/src/features/Container.tsx
+++ b/src/features/Container.tsx
@@ -9,23 +9,24 @@ import DailyBookContainer from './dailyBook/Container';
 import GalleryContainer from './gallery/Container';
 import AboutContainer from './about/Container';
 
+import useScrollMemory from '~/features/shared/hooks/useScrollMemory';
+
 const AppContainer: FunctionComponent = () => {
   const appData = useAppContainer();
   const { activeIndex } = appData;
   const { GALLERY, ABOUT } = PAGE_NAME;
   const needScrollSnap = activeIndex !== GALLERY && activeIndex !== ABOUT;
   const scrollSnapContainer = needScrollSnap ? 'scroll-snap-container' : '';
-  const { containerRef, scrollValue } = useScrollValue(
-    activeIndex,
-    needScrollSnap,
-  );
+  const { containerRef, scrollValue } = useScrollValue(activeIndex, false);
+
+  const { yScroll } = useScrollMemory(containerRef);
 
   return (
     <div
       className={classnames('container', scrollSnapContainer)}
       ref={containerRef}
     >
-      <LandingContainer {...appData} />
+      <LandingContainer {...appData} showLandingAnimation={yScroll === 0} />
       <DailyBookContainer {...appData} />
       <GalleryContainer {...appData} scrollValue={scrollValue} />
       <AboutContainer {...appData} scrollValue={scrollValue} />

--- a/src/features/landing/Container.tsx
+++ b/src/features/landing/Container.tsx
@@ -7,12 +7,15 @@ import ImageSlide from '~/features/landing/components/ImageSlide';
 import LandingTitle from '~/features/landing/components/LandingTitle';
 import { imageSlideElementList } from '~/features/landing/mocks';
 
-type LandingContainerProps = AppData;
+type LandingContainerProps = AppData & {
+  showLandingAnimation: boolean;
+};
 
 const LandingContainer: FunctionComponent<LandingContainerProps> = ({
   refList,
+  showLandingAnimation,
 }) => {
-  const [canShowLanding, setCanShowLanding] = useState(false);
+  const [canShowLanding, setCanShowLanding] = useState(!showLandingAnimation);
 
   const onStartImageSlide = (img: HTMLImageElement, idx: number) => {
     if (idx === imageSlideElementList.length - 1) {
@@ -29,7 +32,9 @@ const LandingContainer: FunctionComponent<LandingContainerProps> = ({
       data-id={PAGE_NAME.LANDING}
       className="landing-container scroll-snap"
     >
-      <ImageSlide onStartImageSlide={onStartImageSlide} />
+      {showLandingAnimation && (
+        <ImageSlide onStartImageSlide={onStartImageSlide} />
+      )}
       {canShowLanding && <LandingTitle />}
     </div>
   );

--- a/src/features/shared/components/Context/YScrollContext.tsx
+++ b/src/features/shared/components/Context/YScrollContext.tsx
@@ -1,0 +1,22 @@
+import {
+  createContext,
+  Dispatch,
+  FunctionComponent,
+  PropsWithChildren,
+  SetStateAction,
+  useState,
+} from 'react';
+
+export const YScrollContext = createContext({
+  yScroll: 0,
+} as { yScroll: number; setYScroll?: Dispatch<SetStateAction<number>> });
+
+export const YScrollProvider: FunctionComponent<PropsWithChildren> = ({
+  children,
+}) => {
+  const [yScroll, setYScroll] = useState(0);
+  const value = { yScroll, setYScroll };
+  return (
+    <YScrollContext.Provider value={value}>{children}</YScrollContext.Provider>
+  );
+};

--- a/src/features/shared/hooks/useScrollMemory.ts
+++ b/src/features/shared/hooks/useScrollMemory.ts
@@ -1,0 +1,25 @@
+import { MutableRefObject, useContext, useEffect, useRef } from 'react';
+
+import { YScrollContext } from '~/features/shared/components/Context/YScrollContext';
+
+const useScrollMemory = (containerRef: MutableRefObject<Element | null>) => {
+  const containerScrollValue = useRef(0);
+  const { yScroll, setYScroll } = useContext(YScrollContext);
+
+  useEffect(() => {
+    containerScrollValue.current = containerRef.current?.scrollTop || 0;
+  }, [containerRef.current?.scrollTop]);
+
+  useEffect(() => {
+    if (yScroll > 0) {
+      containerRef.current?.scrollTo(0, yScroll);
+    }
+    return () => {
+      setYScroll?.(() => containerScrollValue.current || 0);
+    };
+  }, []);
+
+  return { yScroll };
+};
+
+export default useScrollMemory;


### PR DESCRIPTION
## 💡 이슈
resolve #{이슈번호}

## 🤩 개요
디테일 -> 메인으로 갈 때 스크롤값 기억함

## 🧑‍💻 작업 사항
페이지 두개밖에 없어서 다행.......
- 원래, history.pop 리스닝하고 있다가 발생할 때마다 키값과 함께 yscroll 저장하는 복잡한걸 만들어야 함
- 그런데 우리는 디테일 -> 메인으로 가는 시나리오에서만 스크롤이 기억되면 되기 때문에 context랑 ref 사용해서 간단하게 만듦

기억된 스크롤 있는 상황에서는 랜딩 이미지 애니메이션 들어가면 어색할 것 같아서 보여주지 않음

## 📖 참고 사항
![ezgif com-video-to-gif (10)](https://user-images.githubusercontent.com/40057032/222766548-b9d2d5c2-d0e9-42f3-a878-d7ff7f22e867.gif)

클로즈버튼, 뒤로가기 상황에서 정상 동작
새로고침하고 뒤로가기하면 맨 위로 감
