### PR TITLE
fix(landing): 랜딩 개선

### DIFF
--- a/src/features/landing/Container.tsx
+++ b/src/features/landing/Container.tsx
@@ -16,10 +16,17 @@ const LandingContainer: FunctionComponent<LandingContainerProps> = ({
   showLandingAnimation,
 }) => {
   const [canShowLanding, setCanShowLanding] = useState(!showLandingAnimation);
+  const [isLandingAnimationEnded, setIsLandingAnimationEnded] =
+    useState(showLandingAnimation);
 
   const onStartImageSlide = (img: HTMLImageElement, idx: number) => {
     if (idx === imageSlideElementList.length - 1) {
       setCanShowLanding(true);
+    }
+  };
+  const onEndImageSlide = (img: HTMLImageElement, idx: number) => {
+    if (idx === imageSlideElementList.length - 1) {
+      setIsLandingAnimationEnded(false);
     }
   };
 
@@ -32,8 +39,11 @@ const LandingContainer: FunctionComponent<LandingContainerProps> = ({
       data-id={PAGE_NAME.LANDING}
       className="landing-container scroll-snap"
     >
-      {showLandingAnimation && (
-        <ImageSlide onStartImageSlide={onStartImageSlide} />
+      {showLandingAnimation && isLandingAnimationEnded && (
+        <ImageSlide
+          onStartImageSlide={onStartImageSlide}
+          onEndImageSlide={onEndImageSlide}
+        />
       )}
       {canShowLanding && <LandingTitle />}
     </div>

--- a/src/features/landing/components/ImageSlide.tsx
+++ b/src/features/landing/components/ImageSlide.tsx
@@ -8,9 +8,13 @@ import { getFullImgUrl } from '~/features/shared/helpers';
 
 type Props = {
   onStartImageSlide: (image: HTMLImageElement, idx: number) => void;
+  onEndImageSlide: (image: HTMLImageElement, idx: number) => void;
 };
 
-const ImageSlide: FunctionComponent<Props> = ({ onStartImageSlide }) => {
+const ImageSlide: FunctionComponent<Props> = ({
+  onStartImageSlide,
+  onEndImageSlide,
+}) => {
   const ref = useRef<HTMLCanvasElement>(null);
   const { data: images } = usePromises<HTMLImageElement>(
     imageSlideElementList.map((imageId) => fetchImage(getFullImgUrl(imageId))),
@@ -27,12 +31,12 @@ const ImageSlide: FunctionComponent<Props> = ({ onStartImageSlide }) => {
       const ctx = ref.current.getContext('2d');
       if (ctx) ctx.fillStyle = 'transparent';
 
-      startSlide(images, ref?.current, onStartImageSlide);
+      startSlide(images, ref?.current, onStartImageSlide, onEndImageSlide);
     }
   }, [images]);
 
   return (
-    <>
+    <div className="landing-slider-container">
       {!images && <p className="landing-loading">loading</p>}
       <canvas
         className="landing-image-slider"
@@ -40,7 +44,7 @@ const ImageSlide: FunctionComponent<Props> = ({ onStartImageSlide }) => {
         width="1920"
         height="1080"
       />
-    </>
+    </div>
   );
 };
 

--- a/src/features/landing/components/LandingTitle.tsx
+++ b/src/features/landing/components/LandingTitle.tsx
@@ -10,7 +10,7 @@ const LandingTitle: FunctionComponent = () => {
       <div className="cover-title">
         Gallery of our memories
         <br />
-        that we met at Nexter 22nd
+        that we met at Nexters 22nd
         <br />
         jjinn-nolsa
       </div>

--- a/src/features/landing/helper.ts
+++ b/src/features/landing/helper.ts
@@ -32,12 +32,16 @@ const drawImageFrame = (
   delay: number,
   { width, height }: CanvasSize,
   onStartImageSlide?: (image: HTMLImageElement) => void,
+  onEndImageSlide?: (image: HTMLImageElement) => void,
 ) => {
   if (dt - delay < 0) return;
   if (dt - delay < IMAGE_SLIDE_SPEED) onStartImageSlide?.(img);
 
   const dy = height - calcYDistance(dt - delay, IMAGE_SLIDE_ACC);
-  if (dy > width + 3000) return;
+  if (dy < -height - IMAGE_STAY_TERM) {
+    onEndImageSlide?.(img);
+    return;
+  }
   ctx.shadowColor = 'black';
   ctx.shadowBlur = 15;
 
@@ -60,6 +64,7 @@ export const startSlide = (
   images: HTMLImageElement[],
   canvas: HTMLCanvasElement,
   onStartImageSlide?: (image: HTMLImageElement, idx: number) => void,
+  onEndImageSlide?: (image: HTMLImageElement, idx: number) => void,
 ) => {
   const ctx = canvas?.getContext('2d', { alpha: false });
   if (!canvas || !ctx || !images) return;
@@ -78,6 +83,7 @@ export const startSlide = (
         IMAGE_SLIDE_DELAY * idx,
         canvasSize,
         (img: HTMLImageElement) => onStartImageSlide?.(img, idx),
+        (img: HTMLImageElement) => onEndImageSlide?.(img, idx),
       ),
     );
     requestAnimationFrame(() => drawAnimationFrame(dy + IMAGE_SLIDE_SPEED));

--- a/src/features/landing/helper.ts
+++ b/src/features/landing/helper.ts
@@ -15,7 +15,7 @@ export const fetchImage = (src: string) => {
   });
 };
 
-const calcYDistance = (dt: number, a: number): number => {
+export const calcYDistance = (dt: number, a: number): number => {
   return Math.floor((a * dt * dt) / 2);
 };
 
@@ -34,13 +34,13 @@ const drawImageFrame = (
   onStartImageSlide?: (image: HTMLImageElement) => void,
   onEndImageSlide?: (image: HTMLImageElement) => void,
 ) => {
-  if (dt - delay < 0) return;
+  if (dt - delay < 0) return true;
   if (dt - delay < IMAGE_SLIDE_SPEED) onStartImageSlide?.(img);
 
   const dy = height - calcYDistance(dt - delay, IMAGE_SLIDE_ACC);
   if (dy < -height - IMAGE_STAY_TERM) {
     onEndImageSlide?.(img);
-    return;
+    return false;
   }
   ctx.shadowColor = 'black';
   ctx.shadowBlur = 15;
@@ -58,6 +58,8 @@ const drawImageFrame = (
     width,
     height,
   );
+
+  return true;
 };
 
 export const startSlide = (
@@ -75,7 +77,7 @@ export const startSlide = (
     if (dy > canvas.height) return;
 
     ctx.clearRect(0, 0, canvas.width, canvas.height);
-    images.forEach((image, idx) =>
+    const results = images.map((image, idx) =>
       drawImageFrame(
         ctx,
         image,
@@ -86,6 +88,8 @@ export const startSlide = (
         (img: HTMLImageElement) => onEndImageSlide?.(img, idx),
       ),
     );
+    if (results.every((result) => !result)) return;
+
     requestAnimationFrame(() => drawAnimationFrame(dy + IMAGE_SLIDE_SPEED));
   };
 

--- a/src/features/landing/hooks/usePromises.ts
+++ b/src/features/landing/hooks/usePromises.ts
@@ -39,7 +39,10 @@ const usePromises = <T>(promises: Promise<T>[]): State<T> => {
     dispatch({ type: 'loading' });
     (async () => {
       try {
-        const result = await Promise.all(promises);
+        const result = [];
+        for (const p of promises) {
+          result.push(await p);
+        }
         dispatch({ type: 'fetched', payload: result });
       } catch (e) {
         dispatch({ type: 'error', payload: e as Error });

--- a/src/style/landing.scss
+++ b/src/style/landing.scss
@@ -125,16 +125,29 @@ $floating-amount: 25px;
   }
 }
 
-.landing-image-slider {
-  position: absolute;
-  top: 50%;
-  left: 50%;
-  transform: translate(-50%, -50%);
+.landing-slider-container {
+  position: fixed;
+  overflow: hidden;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
   z-index: 2;
-}
 
-.landing-loading {
-  color: white;
+  .landing-image-slider {
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+  }
+
+  .landing-loading {
+    color: white;
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+  }
 }
 
 .landing-title-container {


### PR DESCRIPTION
## 💡 이슈
resolve #{이슈번호}

## 🤩 개요

- 랜딩 이미지 슬라이드 나올때 스크롤 안되게 함
- 랜딩 이미지 슬라이드 끝나면 캔버스 없앰
- 랜딩 이미지 슬라이드 끝나도 슬라이드 그리는 함수가 한동안 돌고 있어서 메모리를 먹고 있었던 것 같음. 이미지 슬라이드 끝나면 함수 실행 안하게 변경
