### PR TITLE
feat: 이미지 최적화

### DIFF
--- a/src/assets/index.html
+++ b/src/assets/index.html
@@ -4,6 +4,10 @@
     <meta charset="UTF-8" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta
+      name="description"
+      content="Gallery of our memories that we met at Nexters 22nd"
+    />
     <link rel="icon" type="image/x-icon" href="./favicon.ico" />
     <title>Let's play interaction!</title>
   </head>

--- a/src/datas/imgList.ts
+++ b/src/datas/imgList.ts
@@ -1,5 +1,6 @@
 import { getFullImgUrl } from '~/features/shared/helpers';
-import { ImgListWithId } from '~/types/index';
+import { ImgListWithId } from '~/types';
+
 const imageDataList: ImgListWithId = [
   {
     id: 1,
@@ -7,7 +8,6 @@ const imageDataList: ImgListWithId = [
     alt: '230107_00',
     width: 2736,
     height: 3648,
-    aspectRatio: 3 / 4,
   },
   {
     id: 2,
@@ -15,7 +15,6 @@ const imageDataList: ImgListWithId = [
     alt: '230112_00',
     width: 1200,
     height: 1800,
-    aspectRatio: 2 / 3,
   },
   {
     id: 3,
@@ -23,7 +22,6 @@ const imageDataList: ImgListWithId = [
     alt: '230112_01',
     width: 3024,
     height: 4032,
-    aspectRatio: 3 / 4,
   },
   {
     id: 4,
@@ -31,7 +29,6 @@ const imageDataList: ImgListWithId = [
     alt: '230114_00',
     width: 1080,
     height: 1920,
-    aspectRatio: 9 / 16,
   },
   {
     id: 5,
@@ -39,7 +36,6 @@ const imageDataList: ImgListWithId = [
     alt: '230114_01',
     width: 2992,
     height: 2992,
-    aspectRatio: 1 / 1,
   },
   {
     id: 6,
@@ -47,7 +43,6 @@ const imageDataList: ImgListWithId = [
     alt: '230114_02',
     width: 2736,
     height: 3648,
-    aspectRatio: 3 / 4,
   },
   {
     id: 7,
@@ -55,7 +50,6 @@ const imageDataList: ImgListWithId = [
     alt: '230114_03',
     width: 2992,
     height: 2992,
-    aspectRatio: 1 / 1,
   },
   {
     id: 8,
@@ -63,7 +57,6 @@ const imageDataList: ImgListWithId = [
     alt: '230128_00',
     width: 3000,
     height: 4000,
-    aspectRatio: 3 / 4,
   },
   {
     id: 9,
@@ -71,7 +64,6 @@ const imageDataList: ImgListWithId = [
     alt: '230128_01',
     width: 3000,
     height: 4000,
-    aspectRatio: 3 / 4,
   },
   {
     id: 10,
@@ -79,7 +71,6 @@ const imageDataList: ImgListWithId = [
     alt: '230128_02',
     width: 3000,
     height: 4000,
-    aspectRatio: 3 / 4,
   },
   {
     id: 11,
@@ -87,7 +78,6 @@ const imageDataList: ImgListWithId = [
     alt: '230128_03',
     width: 3000,
     height: 4000,
-    aspectRatio: 3 / 4,
   },
   {
     id: 12,
@@ -95,7 +85,6 @@ const imageDataList: ImgListWithId = [
     alt: '230204_00',
     width: 2736,
     height: 3648,
-    aspectRatio: 3 / 4,
   },
   {
     id: 13,
@@ -103,7 +92,6 @@ const imageDataList: ImgListWithId = [
     alt: '230204_01',
     width: 3088,
     height: 2320,
-    aspectRatio: 30 / 23,
   },
   {
     id: 14,
@@ -111,7 +99,6 @@ const imageDataList: ImgListWithId = [
     alt: '230204_02',
     width: 2232,
     height: 3968,
-    aspectRatio: 22 / 39,
   },
   {
     id: 15,
@@ -119,7 +106,6 @@ const imageDataList: ImgListWithId = [
     alt: '230204_04',
     width: 2252,
     height: 4000,
-    aspectRatio: 22 / 40,
   },
   {
     id: 16,
@@ -127,7 +113,6 @@ const imageDataList: ImgListWithId = [
     alt: '230204_05',
     width: 2252,
     height: 4000,
-    aspectRatio: 22 / 40,
   },
   {
     id: 17,
@@ -135,7 +120,6 @@ const imageDataList: ImgListWithId = [
     alt: '230204_06',
     width: 4032,
     height: 3024,
-    aspectRatio: 4 / 3,
   },
   {
     id: 18,
@@ -143,7 +127,6 @@ const imageDataList: ImgListWithId = [
     alt: '230204_07',
     width: 3024,
     height: 4032,
-    aspectRatio: 3 / 4,
   },
   {
     id: 19,
@@ -151,7 +134,6 @@ const imageDataList: ImgListWithId = [
     alt: '230204_08',
     width: 3024,
     height: 4032,
-    aspectRatio: 3 / 4,
   },
   {
     id: 20,
@@ -159,7 +141,6 @@ const imageDataList: ImgListWithId = [
     alt: '230209_00',
     width: 1988,
     height: 1192,
-    aspectRatio: 5 / 3,
   },
   {
     id: 21,
@@ -167,7 +148,6 @@ const imageDataList: ImgListWithId = [
     alt: '230211_00',
     width: 2232,
     height: 3968,
-    aspectRatio: 22 / 39,
   },
   {
     id: 22,
@@ -175,7 +155,6 @@ const imageDataList: ImgListWithId = [
     alt: '230211_01',
     width: 4000,
     height: 3000,
-    aspectRatio: 4 / 3,
   },
   {
     id: 23,
@@ -183,7 +162,6 @@ const imageDataList: ImgListWithId = [
     alt: '230211_02',
     width: 4000,
     height: 3000,
-    aspectRatio: 4 / 3,
   },
   {
     id: 24,
@@ -191,7 +169,6 @@ const imageDataList: ImgListWithId = [
     alt: '230211_03',
     width: 4000,
     height: 3000,
-    aspectRatio: 4 / 3,
   },
   {
     id: 25,
@@ -199,7 +176,6 @@ const imageDataList: ImgListWithId = [
     alt: '230211_05',
     width: 2252,
     height: 4000,
-    aspectRatio: 11 / 20,
   },
   {
     id: 26,
@@ -207,7 +183,6 @@ const imageDataList: ImgListWithId = [
     alt: '230211_06',
     width: 2252,
     height: 4000,
-    aspectRatio: 11 / 20,
   },
   {
     id: 27,
@@ -215,7 +190,6 @@ const imageDataList: ImgListWithId = [
     alt: '230211_07',
     width: 2252,
     height: 4000,
-    aspectRatio: 11 / 20,
   },
   {
     id: 28,
@@ -223,7 +197,6 @@ const imageDataList: ImgListWithId = [
     alt: '230211_08',
     width: 2252,
     height: 4000,
-    aspectRatio: 11 / 20,
   },
   {
     id: 29,
@@ -231,7 +204,6 @@ const imageDataList: ImgListWithId = [
     alt: '230211_09',
     width: 3024,
     height: 3024,
-    aspectRatio: 1 / 1,
   },
   {
     id: 30,
@@ -239,7 +211,6 @@ const imageDataList: ImgListWithId = [
     alt: '230211_10',
     width: 2252,
     height: 4000,
-    aspectRatio: 11 / 20,
   },
   {
     id: 31,
@@ -247,7 +218,6 @@ const imageDataList: ImgListWithId = [
     alt: '230211_11',
     width: 3024,
     height: 3024,
-    aspectRatio: 1 / 1,
   },
   {
     id: 32,
@@ -255,7 +225,6 @@ const imageDataList: ImgListWithId = [
     alt: '230211_12',
     width: 2160,
     height: 2880,
-    aspectRatio: 3 / 4,
   },
   {
     id: 33,
@@ -263,7 +232,6 @@ const imageDataList: ImgListWithId = [
     alt: '230216_00',
     width: 1200,
     height: 1800,
-    aspectRatio: 2 / 3,
   },
   {
     id: 34,
@@ -271,7 +239,6 @@ const imageDataList: ImgListWithId = [
     alt: '230218_00',
     width: 1278,
     height: 828,
-    aspectRatio: 3 / 2,
   },
   {
     id: 35,
@@ -279,7 +246,6 @@ const imageDataList: ImgListWithId = [
     alt: '230218_01',
     width: 822,
     height: 630,
-    aspectRatio: 4 / 3,
   },
   {
     id: 36,
@@ -287,7 +253,6 @@ const imageDataList: ImgListWithId = [
     alt: '230219_00',
     width: 2138,
     height: 3207,
-    aspectRatio: 21 / 32,
   },
   {
     id: 37,
@@ -295,7 +260,6 @@ const imageDataList: ImgListWithId = [
     alt: '230219_01',
     width: 2138,
     height: 3207,
-    aspectRatio: 21 / 32,
   },
   {
     id: 38,
@@ -303,7 +267,6 @@ const imageDataList: ImgListWithId = [
     alt: '230219_02',
     width: 2138,
     height: 3207,
-    aspectRatio: 21 / 32,
   },
   {
     id: 39,
@@ -311,7 +274,6 @@ const imageDataList: ImgListWithId = [
     alt: '230219_03',
     width: 2138,
     height: 3207,
-    aspectRatio: 21 / 32,
   },
   {
     id: 40,
@@ -319,7 +281,6 @@ const imageDataList: ImgListWithId = [
     alt: '230219_04',
     width: 2138,
     height: 3207,
-    aspectRatio: 21 / 32,
   },
   {
     id: 41,
@@ -327,7 +288,6 @@ const imageDataList: ImgListWithId = [
     alt: '230219_05',
     width: 2138,
     height: 3207,
-    aspectRatio: 21 / 32,
   },
   {
     id: 42,
@@ -335,7 +295,6 @@ const imageDataList: ImgListWithId = [
     alt: '230219_06',
     width: 3000,
     height: 4000,
-    aspectRatio: 3 / 4,
   },
   {
     id: 43,
@@ -343,7 +302,6 @@ const imageDataList: ImgListWithId = [
     alt: '230219_07',
     width: 2160,
     height: 2880,
-    aspectRatio: 3 / 4,
   },
   {
     id: 44,
@@ -351,7 +309,6 @@ const imageDataList: ImgListWithId = [
     alt: '230219_08',
     width: 3024,
     height: 3024,
-    aspectRatio: 1 / 1,
   },
   {
     id: 45,
@@ -359,7 +316,6 @@ const imageDataList: ImgListWithId = [
     alt: '230219_09',
     width: 3024,
     height: 3024,
-    aspectRatio: 1 / 1,
   },
   {
     id: 46,
@@ -367,7 +323,6 @@ const imageDataList: ImgListWithId = [
     alt: '230225_00',
     width: 3088,
     height: 2100,
-    aspectRatio: 10 / 7,
   },
   {
     id: 47,
@@ -375,7 +330,6 @@ const imageDataList: ImgListWithId = [
     alt: '230225_01',
     width: 500,
     height: 500,
-    aspectRatio: 1 / 1,
   },
   {
     id: 48,
@@ -383,7 +337,6 @@ const imageDataList: ImgListWithId = [
     alt: 'last',
     width: 1690,
     height: 1350,
-    aspectRatio: 169 / 135,
   },
   {
     id: 49,
@@ -391,13 +344,13 @@ const imageDataList: ImgListWithId = [
     alt: '230211_04',
     width: 4000,
     height: 3000,
-    aspectRatio: 4 / 3,
   },
 ];
 
 export const imageDataListWithPrefix: ImgListWithId = imageDataList.map(
   ({ src, ...rest }) => ({
     src: getFullImgUrl(src),
+    aspectRatio: rest.width && rest.height ? rest.width / rest.height : 1,
     ...rest,
   }),
 );

--- a/src/features/about/Container.tsx
+++ b/src/features/about/Container.tsx
@@ -142,6 +142,7 @@ const AboutContainer: FunctionComponent<AboutContainerProps> = ({
                     alt="basicImage"
                     width={603}
                     height={603}
+                    options={{ fit: 'crop' }}
                   />
                 </div>
               ))}

--- a/src/features/about/Container.tsx
+++ b/src/features/about/Container.tsx
@@ -7,6 +7,7 @@ import { AboutContainerProps } from './types';
 
 import Image from '~/features/shared/components/Image';
 import { getImageUrlWithCdn } from '~/features/shared/utils/url';
+import { PHOTO_PATH_PREFIX } from '~/features/shared/constants';
 
 const AboutContainer: FunctionComponent<AboutContainerProps> = ({
   scrollValue,
@@ -64,7 +65,7 @@ const AboutContainer: FunctionComponent<AboutContainerProps> = ({
               backgroundImage: `url(${getImageUrlWithCdn(
                 selectedName >= 0
                   ? PROFILES_REPEAT[selectedName].src
-                  : 'https://raw.githubusercontent.com/Nexters/who-really-wants-to-play/images/images/profile/sc.webp',
+                  : PHOTO_PATH_PREFIX + '/profile/sc.webp',
               )})`,
             }}
           >

--- a/src/features/about/Container.tsx
+++ b/src/features/about/Container.tsx
@@ -5,6 +5,9 @@ import { useGetStartScrollY } from './hooks/\buseGetStartScrollY';
 import { useIntroInteraction } from './hooks/useInteraction';
 import { AboutContainerProps } from './types';
 
+import Image from '~/features/shared/components/Image';
+import { getImageUrlWithCdn } from '~/features/shared/utils/url';
+
 const AboutContainer: FunctionComponent<AboutContainerProps> = ({
   scrollValue,
 }) => {
@@ -58,11 +61,11 @@ const AboutContainer: FunctionComponent<AboutContainerProps> = ({
                   ? PROFILES_REPEAT[selectedName].color
                   : '#bfe0b0'
               }`,
-              backgroundImage: `url(${
+              backgroundImage: `url(${getImageUrlWithCdn(
                 selectedName >= 0
                   ? PROFILES_REPEAT[selectedName].src
-                  : 'https://raw.githubusercontent.com/Nexters/who-really-wants-to-play/images/images/profile/sc.webp'
-              })`,
+                  : 'https://raw.githubusercontent.com/Nexters/who-really-wants-to-play/images/images/profile/sc.webp',
+              )})`,
             }}
           >
             <div
@@ -129,7 +132,7 @@ const AboutContainer: FunctionComponent<AboutContainerProps> = ({
                   key={index}
                   style={{ opacity: `${imageOpacity}`, top: `${imageTop}%` }}
                 >
-                  <img
+                  <Image
                     className={
                       selectedName === index
                         ? 'about-selected-img'

--- a/src/features/about/constants.ts
+++ b/src/features/about/constants.ts
@@ -1,4 +1,6 @@
-import { IntroInfoSettings } from "./types";
+import { IntroInfoSettings } from './types';
+
+import { PHOTO_PATH_PREFIX } from '~/features/shared/constants';
 
 export const TITLE = 'About us';
 
@@ -7,37 +9,37 @@ const PROFILES_LIST = [
     name: 'Lee Sangchul',
     job: 'PM, Developer',
     color: '#BFE0B0',
-    src: 'https://raw.githubusercontent.com/Nexters/who-really-wants-to-play/images/images/profile/sc.webp',
+    src: PHOTO_PATH_PREFIX + '/profile/sc.webp',
   },
   {
     name: 'An Yulim',
     job: 'Developer',
     color: '#C8B0E0',
-    src: 'https://raw.githubusercontent.com/Nexters/who-really-wants-to-play/images/images/profile/yl.webp',
+    src: PHOTO_PATH_PREFIX + '/profile/yl.webp',
   },
   {
     name: 'Kim Dongyong',
     job: 'Developer',
     color: '#E0BCB0',
-    src: 'https://raw.githubusercontent.com/Nexters/who-really-wants-to-play/images/images/profile/dy.webp',
+    src: PHOTO_PATH_PREFIX + '/profile/dy.webp',
   },
   {
     name: 'Cho Yejin',
     job: 'Developer',
     color: '#E0D8B0',
-    src: 'https://raw.githubusercontent.com/Nexters/who-really-wants-to-play/images/images/profile/yj.webp',
+    src: PHOTO_PATH_PREFIX + '/profile/yj.webp',
   },
   {
     name: 'Kim Yeonghwan',
     job: 'Designer',
     color: '#B0D4E0',
-    src: 'https://raw.githubusercontent.com/Nexters/who-really-wants-to-play/images/images/profile/yh.webp',
+    src: PHOTO_PATH_PREFIX + '/profile/yh.webp',
   },
   {
     name: 'Lee Hyebin',
     job: 'Designer',
     color: '#E0B0BC',
-    src: 'https://raw.githubusercontent.com/Nexters/who-really-wants-to-play/images/images/profile/hb.webp',
+    src: PHOTO_PATH_PREFIX + '/profile/hb.webp',
   },
 ];
 
@@ -48,8 +50,16 @@ export const PROFILES_REPEAT = [
 ];
 
 const range = (start: number, stop: number, step: number) => {
-  return Array.from({ length: (stop - start) / step + 1}, (_, i) => start + (i * step));}
-export const PROFILES_LIST_SCROLL = range(200, 200*PROFILES_REPEAT.length, 200);
+  return Array.from(
+    { length: (stop - start) / step + 1 },
+    (_, i) => start + i * step,
+  );
+};
+export const PROFILES_LIST_SCROLL = range(
+  200,
+  200 * PROFILES_REPEAT.length,
+  200,
+);
 
 export const INTRO_SETTINGS: IntroInfoSettings = {
   titleOpacity: {

--- a/src/features/dailyBook/components/CoverImage.tsx
+++ b/src/features/dailyBook/components/CoverImage.tsx
@@ -55,6 +55,7 @@ const BackgroundImage: FunctionComponent<
           alt="cover"
           width={600 - gradualDecline}
           height={600 - gradualDecline}
+          options={{ fit: 'crop' }}
         />
       )}
     </div>

--- a/src/features/dailyBook/constants.ts
+++ b/src/features/dailyBook/constants.ts
@@ -1,4 +1,5 @@
 import { DailyBookData } from '~/features/dailyBook/types';
+import { PHOTO_PATH_PREFIX } from '~/features/shared/constants';
 
 export const LANDING_INDEX_COUNT = 1;
 export const MAX_DIAL_COUNT = 6;
@@ -12,8 +13,7 @@ export const data: DailyBookData[] = [
     description: 'Gallery of our memories that we met at Nexters 22nd',
     date: '01.07',
     customClass: 'dailybook0',
-    coverImage:
-      'https://raw.githubusercontent.com/Nexters/who-really-wants-to-play/images/images/230107/230107_00.webp',
+    coverImage: PHOTO_PATH_PREFIX + '/230107/230107_00.webp',
     detail: {
       bgColor: '#e0b0b0',
       keywords: [
@@ -25,9 +25,7 @@ export const data: DailyBookData[] = [
       ],
       description:
         'We met for the first time at the orientation of the 22nd generation of Nexters. Young-hwan was absent due to work, but the others gathered together to greet each other.',
-      imgSrcs: [
-        'https://raw.githubusercontent.com/Nexters/who-really-wants-to-play/images/images/230107/230107_00.webp',
-      ],
+      imgSrcs: [PHOTO_PATH_PREFIX + '/230107/230107_00.webp'],
     },
   },
   {
@@ -36,8 +34,7 @@ export const data: DailyBookData[] = [
     description: 'Gallery of our memories that we met at Nexters 22nd',
     date: '01.12',
     customClass: 'dailybook1',
-    coverImage:
-      'https://raw.githubusercontent.com/Nexters/who-really-wants-to-play/images/images/230112/230112_00.webp',
+    coverImage: PHOTO_PATH_PREFIX + '/230112/230112_00.webp',
     detail: {
       bgColor: '#b0c9e0',
       keywords: [
@@ -49,9 +46,7 @@ export const data: DailyBookData[] = [
       ],
       description:
         'We met for the first time at the orientation of the 22nd generation of Nexters. Young-hwan was absent due to work, but the others gathered together to greet each other.',
-      imgSrcs: [
-        'https://raw.githubusercontent.com/Nexters/who-really-wants-to-play/images/images/230112/230112_00.webp',
-      ],
+      imgSrcs: [PHOTO_PATH_PREFIX + '/230112/230112_00.webp'],
     },
   },
   {
@@ -60,8 +55,7 @@ export const data: DailyBookData[] = [
     description: 'Gallery of our memories that we met at Nexters 22nd',
     date: '01.14',
     customClass: 'dailybook2',
-    coverImage:
-      'https://raw.githubusercontent.com/Nexters/who-really-wants-to-play/images/images/230114/230114_00.webp',
+    coverImage: PHOTO_PATH_PREFIX + '/230114/230114_00.webp',
     detail: {
       bgColor: '#e0c7b0',
       keywords: [
@@ -74,10 +68,10 @@ export const data: DailyBookData[] = [
       description:
         'We met for the first time at the orientation of the 22nd generation of Nexters. Young-hwan was absent due to work, but the others gathered together to greet each other.',
       imgSrcs: [
-        'https://raw.githubusercontent.com/Nexters/who-really-wants-to-play/images/images/230114/230114_00.webp',
-        'https://raw.githubusercontent.com/Nexters/who-really-wants-to-play/images/images/230114/230114_01.webp',
-        'https://raw.githubusercontent.com/Nexters/who-really-wants-to-play/images/images/230114/230114_02.webp',
-        'https://raw.githubusercontent.com/Nexters/who-really-wants-to-play/images/images/230114/230114_03.webp',
+        PHOTO_PATH_PREFIX + '/230114/230114_00.webp',
+        PHOTO_PATH_PREFIX + '/230114/230114_01.webp',
+        PHOTO_PATH_PREFIX + '/230114/230114_02.webp',
+        PHOTO_PATH_PREFIX + '/230114/230114_03.webp',
       ],
     },
   },
@@ -87,8 +81,7 @@ export const data: DailyBookData[] = [
     description: 'Gallery of our memories that we met at Nexters 22nd',
     date: '01.28',
     customClass: 'dailybook3',
-    coverImage:
-      'https://raw.githubusercontent.com/Nexters/who-really-wants-to-play/images/images/230128/230128_00.webp',
+    coverImage: PHOTO_PATH_PREFIX + '/230128/230128_00.webp',
     detail: {
       bgColor: '#bfb0e0',
       keywords: [
@@ -101,10 +94,10 @@ export const data: DailyBookData[] = [
       description:
         'We met for the first time at the orientation of the 22nd generation of Nexters. Young-hwan was absent due to work, but the others gathered together to greet each other.',
       imgSrcs: [
-        'https://raw.githubusercontent.com/Nexters/who-really-wants-to-play/images/images/230128/230128_00.webp',
-        'https://raw.githubusercontent.com/Nexters/who-really-wants-to-play/images/images/230128/230128_01.webp',
-        'https://raw.githubusercontent.com/Nexters/who-really-wants-to-play/images/images/230128/230128_02.webp',
-        'https://raw.githubusercontent.com/Nexters/who-really-wants-to-play/images/images/230128/230128_03.webp',
+        PHOTO_PATH_PREFIX + '/230128/230128_00.webp',
+        PHOTO_PATH_PREFIX + '/230128/230128_01.webp',
+        PHOTO_PATH_PREFIX + '/230128/230128_02.webp',
+        PHOTO_PATH_PREFIX + '/230128/230128_03.webp',
       ],
     },
   },
@@ -114,8 +107,7 @@ export const data: DailyBookData[] = [
     description: 'Gallery of our memories that we met at Nexters 22nd',
     date: '02.04',
     customClass: 'dailybook4',
-    coverImage:
-      'https://raw.githubusercontent.com/Nexters/who-really-wants-to-play/images/images/230204/230204_00.webp',
+    coverImage: PHOTO_PATH_PREFIX + '/230204/230204_00.webp',
     detail: {
       bgColor: '#b0e0d7',
       keywords: [
@@ -128,14 +120,14 @@ export const data: DailyBookData[] = [
       description:
         'We met for the first time at the orientation of the 22nd generation of Nexters. Young-hwan was absent due to work, but the others gathered together to greet each other.',
       imgSrcs: [
-        'https://raw.githubusercontent.com/Nexters/who-really-wants-to-play/images/images/230204/230204_00.webp',
-        'https://raw.githubusercontent.com/Nexters/who-really-wants-to-play/images/images/230204/230204_01.webp',
-        'https://raw.githubusercontent.com/Nexters/who-really-wants-to-play/images/images/230204/230204_02.webp',
-        'https://raw.githubusercontent.com/Nexters/who-really-wants-to-play/images/images/230204/230204_04.webp',
-        'https://raw.githubusercontent.com/Nexters/who-really-wants-to-play/images/images/230204/230204_05.webp',
-        'https://raw.githubusercontent.com/Nexters/who-really-wants-to-play/images/images/230204/230204_06.webp',
-        'https://raw.githubusercontent.com/Nexters/who-really-wants-to-play/images/images/230204/230204_07.webp',
-        'https://raw.githubusercontent.com/Nexters/who-really-wants-to-play/images/images/230204/230204_08.webp',
+        PHOTO_PATH_PREFIX + '/230204/230204_00.webp',
+        PHOTO_PATH_PREFIX + '/230204/230204_01.webp',
+        PHOTO_PATH_PREFIX + '/230204/230204_02.webp',
+        PHOTO_PATH_PREFIX + '/230204/230204_04.webp',
+        PHOTO_PATH_PREFIX + '/230204/230204_05.webp',
+        PHOTO_PATH_PREFIX + '/230204/230204_06.webp',
+        PHOTO_PATH_PREFIX + '/230204/230204_07.webp',
+        PHOTO_PATH_PREFIX + '/230204/230204_08.webp',
       ],
     },
   },
@@ -145,8 +137,7 @@ export const data: DailyBookData[] = [
     description: 'Gallery of our memories that we met at Nexters 22nd',
     date: '02.09',
     customClass: 'dailybook5',
-    coverImage:
-      'https://raw.githubusercontent.com/Nexters/who-really-wants-to-play/images/images/230209/230209_00.webp',
+    coverImage: PHOTO_PATH_PREFIX + '/230209/230209_00.webp',
     detail: {
       bgColor: '#67a6c0',
       keywords: [
@@ -158,9 +149,7 @@ export const data: DailyBookData[] = [
       ],
       description:
         'We met for the first time at the orientation of the 22nd generation of Nexters. Young-hwan was absent due to work, but the others gathered together to greet each other.',
-      imgSrcs: [
-        'https://raw.githubusercontent.com/Nexters/who-really-wants-to-play/images/images/230209/230209_00.webp',
-      ],
+      imgSrcs: [PHOTO_PATH_PREFIX + '/230209/230209_00.webp'],
     },
   },
   {
@@ -169,8 +158,7 @@ export const data: DailyBookData[] = [
     description: 'Gallery of our memories that we met at Nexters 22nd',
     date: '02.11',
     customClass: 'dailybook6',
-    coverImage:
-      'https://raw.githubusercontent.com/Nexters/who-really-wants-to-play/images/images/230211/230211_00.webp',
+    coverImage: PHOTO_PATH_PREFIX + '/230211/230211_00.webp',
     detail: {
       bgColor: '#b0e0b4',
       keywords: [
@@ -183,19 +171,19 @@ export const data: DailyBookData[] = [
       description:
         'We met for the first time at the orientation of the 22nd generation of Nexters. Young-hwan was absent due to work, but the others gathered together to greet each other.',
       imgSrcs: [
-        'https://raw.githubusercontent.com/Nexters/who-really-wants-to-play/images/images/230211/230211_00.webp',
-        'https://raw.githubusercontent.com/Nexters/who-really-wants-to-play/images/images/230211/230211_01.webp',
-        'https://raw.githubusercontent.com/Nexters/who-really-wants-to-play/images/images/230211/230211_02.webp',
-        'https://raw.githubusercontent.com/Nexters/who-really-wants-to-play/images/images/230211/230211_03.webp',
-        'https://raw.githubusercontent.com/Nexters/who-really-wants-to-play/images/images/230211/230211_04.webp',
-        'https://raw.githubusercontent.com/Nexters/who-really-wants-to-play/images/images/230211/230211_05.webp',
-        'https://raw.githubusercontent.com/Nexters/who-really-wants-to-play/images/images/230211/230211_06.webp',
-        'https://raw.githubusercontent.com/Nexters/who-really-wants-to-play/images/images/230211/230211_07.webp',
-        'https://raw.githubusercontent.com/Nexters/who-really-wants-to-play/images/images/230211/230211_08.webp',
-        'https://raw.githubusercontent.com/Nexters/who-really-wants-to-play/images/images/230211/230211_09.webp',
-        'https://raw.githubusercontent.com/Nexters/who-really-wants-to-play/images/images/230211/230211_10.webp',
-        'https://raw.githubusercontent.com/Nexters/who-really-wants-to-play/images/images/230211/230211_11.webp',
-        'https://raw.githubusercontent.com/Nexters/who-really-wants-to-play/images/images/230211/230211_12.webp',
+        PHOTO_PATH_PREFIX + '/230211/230211_00.webp',
+        PHOTO_PATH_PREFIX + '/230211/230211_01.webp',
+        PHOTO_PATH_PREFIX + '/230211/230211_02.webp',
+        PHOTO_PATH_PREFIX + '/230211/230211_03.webp',
+        PHOTO_PATH_PREFIX + '/230211/230211_04.webp',
+        PHOTO_PATH_PREFIX + '/230211/230211_05.webp',
+        PHOTO_PATH_PREFIX + '/230211/230211_06.webp',
+        PHOTO_PATH_PREFIX + '/230211/230211_07.webp',
+        PHOTO_PATH_PREFIX + '/230211/230211_08.webp',
+        PHOTO_PATH_PREFIX + '/230211/230211_09.webp',
+        PHOTO_PATH_PREFIX + '/230211/230211_10.webp',
+        PHOTO_PATH_PREFIX + '/230211/230211_11.webp',
+        PHOTO_PATH_PREFIX + '/230211/230211_12.webp',
       ],
     },
   },
@@ -205,8 +193,7 @@ export const data: DailyBookData[] = [
     description: 'Gallery of our memories that we met at Nexters 22nd',
     date: '02.16',
     customClass: 'dailybook7',
-    coverImage:
-      'https://raw.githubusercontent.com/Nexters/who-really-wants-to-play/images/images/230216/230216_00.webp',
+    coverImage: PHOTO_PATH_PREFIX + '/230216/230216_00.webp',
     detail: {
       bgColor: '#a75490',
       keywords: [
@@ -218,9 +205,7 @@ export const data: DailyBookData[] = [
       ],
       description:
         'We met for the first time at the orientation of the 22nd generation of Nexters. Young-hwan was absent due to work, but the others gathered together to greet each other.',
-      imgSrcs: [
-        'https://raw.githubusercontent.com/Nexters/who-really-wants-to-play/images/images/230216/230216_00.webp',
-      ],
+      imgSrcs: [PHOTO_PATH_PREFIX + '/230216/230216_00.webp'],
     },
   },
   {
@@ -229,8 +214,7 @@ export const data: DailyBookData[] = [
     description: 'Gallery of our memories that we met at Nexters 22nd',
     date: '02.18',
     customClass: 'dailybook8',
-    coverImage:
-      'https://raw.githubusercontent.com/Nexters/who-really-wants-to-play/images/images/230218/230218_00.webp',
+    coverImage: PHOTO_PATH_PREFIX + '/230218/230218_00.webp',
     detail: {
       bgColor: '#eba48e',
       keywords: [
@@ -242,9 +226,7 @@ export const data: DailyBookData[] = [
       ],
       description:
         'We met for the first time at the orientation of the 22nd generation of Nexters. Young-hwan was absent due to work, but the others gathered together to greet each other.',
-      imgSrcs: [
-        'https://raw.githubusercontent.com/Nexters/who-really-wants-to-play/images/images/230218/230218_00.webp',
-      ],
+      imgSrcs: [PHOTO_PATH_PREFIX + '/230218/230218_00.webp'],
     },
   },
   {
@@ -253,8 +235,7 @@ export const data: DailyBookData[] = [
     description: 'Gallery of our memories that we met at Nexters 22nd',
     date: '02.19',
     customClass: 'dailybook9',
-    coverImage:
-      'https://raw.githubusercontent.com/Nexters/who-really-wants-to-play/images/images/230219/230219_00.webp',
+    coverImage: PHOTO_PATH_PREFIX + '/230219/230219_00.webp',
     detail: {
       bgColor: '#7c7baf',
       keywords: [
@@ -267,16 +248,16 @@ export const data: DailyBookData[] = [
       description:
         'We met for the first time at the orientation of the 22nd generation of Nexters. Young-hwan was absent due to work, but the others gathered together to greet each other.',
       imgSrcs: [
-        'https://raw.githubusercontent.com/Nexters/who-really-wants-to-play/images/images/230219/230219_00.webp',
-        'https://raw.githubusercontent.com/Nexters/who-really-wants-to-play/images/images/230219/230219_01.webp',
-        'https://raw.githubusercontent.com/Nexters/who-really-wants-to-play/images/images/230219/230219_02.webp',
-        'https://raw.githubusercontent.com/Nexters/who-really-wants-to-play/images/images/230219/230219_03.webp',
-        'https://raw.githubusercontent.com/Nexters/who-really-wants-to-play/images/images/230219/230219_04.webp',
-        'https://raw.githubusercontent.com/Nexters/who-really-wants-to-play/images/images/230219/230219_05.webp',
-        'https://raw.githubusercontent.com/Nexters/who-really-wants-to-play/images/images/230219/230219_06.webp',
-        'https://raw.githubusercontent.com/Nexters/who-really-wants-to-play/images/images/230219/230219_07.webp',
-        'https://raw.githubusercontent.com/Nexters/who-really-wants-to-play/images/images/230219/230219_08.webp',
-        'https://raw.githubusercontent.com/Nexters/who-really-wants-to-play/images/images/230219/230219_09.webp',
+        PHOTO_PATH_PREFIX + '/230219/230219_00.webp',
+        PHOTO_PATH_PREFIX + '/230219/230219_01.webp',
+        PHOTO_PATH_PREFIX + '/230219/230219_02.webp',
+        PHOTO_PATH_PREFIX + '/230219/230219_03.webp',
+        PHOTO_PATH_PREFIX + '/230219/230219_04.webp',
+        PHOTO_PATH_PREFIX + '/230219/230219_05.webp',
+        PHOTO_PATH_PREFIX + '/230219/230219_06.webp',
+        PHOTO_PATH_PREFIX + '/230219/230219_07.webp',
+        PHOTO_PATH_PREFIX + '/230219/230219_08.webp',
+        PHOTO_PATH_PREFIX + '/230219/230219_09.webp',
       ],
     },
   },
@@ -286,8 +267,7 @@ export const data: DailyBookData[] = [
     description: 'Gallery of our memories that we met at Nexters 22nd',
     date: '02.25',
     customClass: 'dailybook10',
-    coverImage:
-      'https://raw.githubusercontent.com/Nexters/who-really-wants-to-play/images/images/230225/230225_00.webp',
+    coverImage: PHOTO_PATH_PREFIX + '/230225/230225_00.webp',
     detail: {
       bgColor: '#a75490',
       keywords: [
@@ -300,8 +280,8 @@ export const data: DailyBookData[] = [
       description:
         'We met for the first time at the orientation of the 22nd generation of Nexters. Young-hwan was absent due to work, but the others gathered together to greet each other.',
       imgSrcs: [
-        'https://raw.githubusercontent.com/Nexters/who-really-wants-to-play/images/images/230225/230225_00.webp',
-        'https://raw.githubusercontent.com/Nexters/who-really-wants-to-play/images/images/230225/230225_01.webp',
+        PHOTO_PATH_PREFIX + '/230225/230225_00.webp',
+        PHOTO_PATH_PREFIX + '/230225/230225_01.webp',
       ],
     },
   },

--- a/src/features/detail/components/CloseButton.tsx
+++ b/src/features/detail/components/CloseButton.tsx
@@ -9,7 +9,12 @@ type Props = {
 const CloseButton: FunctionComponent<Props> = ({ onClick }) => {
   return (
     <button className="close-button" onClick={onClick}>
-      <Image src={`${PHOTO_PATH_PREFIX}/svg/close.svg`} alt="닫기 버튼" />
+      <Image
+        src={`${PHOTO_PATH_PREFIX}/svg/close.svg`}
+        alt="닫기 버튼"
+        width={40}
+        height={40}
+      />
     </button>
   );
 };

--- a/src/features/detail/components/Cover.tsx
+++ b/src/features/detail/components/Cover.tsx
@@ -7,6 +7,7 @@ import CloseButton from '~/features/detail/components/CloseButton';
 import { PAGE_NAME, PHOTO_PATH_PREFIX } from '~/features/shared/constants';
 import { AppData } from '~/features/types';
 import { fetchImage } from '~/features/landing/helper';
+import { getImageUrlWithCdn } from '~/features/shared/utils/url';
 
 type Props = AppData & {
   bgColor: string;
@@ -26,7 +27,7 @@ const Cover: FunctionComponent<Props> = ({
   const [scale, setScale] = useState(1);
 
   const calcScale = async () => {
-    const image = await fetchImage(imgSrc);
+    const image = await fetchImage(getImageUrlWithCdn(imgSrc), { q: 1 });
     const w = image.width;
     const h = image.height;
     const scaleX = window.innerWidth / w;
@@ -79,6 +80,8 @@ const Cover: FunctionComponent<Props> = ({
           <Image
             src={`${PHOTO_PATH_PREFIX}/svg/detail-scroll-down.svg`}
             alt="스크롤 다운 이미지"
+            width={52.5}
+            height={69.5}
           />
         </div>
       </div>

--- a/src/features/detail/components/ImageSlider.tsx
+++ b/src/features/detail/components/ImageSlider.tsx
@@ -1,4 +1,4 @@
-import { FunctionComponent, useMemo } from 'react';
+import { FunctionComponent } from 'react';
 
 import Image from '~/features/shared/components/Image';
 
@@ -15,8 +15,6 @@ const ImageSlider: FunctionComponent<Props> = ({
   paused,
   onClickImage,
 }) => {
-  const imageWidth = useMemo(() => window.innerWidth * 0.18, []);
-
   return (
     <div className={`image-slide ${direction} ${paused ? 'pause' : ''}`}>
       {imgSrcs.map((src, idx) => (
@@ -25,7 +23,7 @@ const ImageSlider: FunctionComponent<Props> = ({
           className="image-slide-element"
           src={src}
           alt={`이미지 슬라이드 ${idx + 1}번째`}
-          width={imageWidth}
+          width={600}
           onClick={() => onClickImage(src)}
         />
       ))}
@@ -36,7 +34,7 @@ const ImageSlider: FunctionComponent<Props> = ({
             className="image-slide-element"
             src={src}
             alt={`이미지 슬라이드 ${idx + 1}번째`}
-            width={imageWidth}
+            width={600}
             onClick={() => onClickImage(src)}
           />
         ))}

--- a/src/features/detail/components/ImageSlider.tsx
+++ b/src/features/detail/components/ImageSlider.tsx
@@ -1,4 +1,4 @@
-import { FunctionComponent } from 'react';
+import { FunctionComponent, useMemo } from 'react';
 
 import Image from '~/features/shared/components/Image';
 
@@ -15,6 +15,8 @@ const ImageSlider: FunctionComponent<Props> = ({
   paused,
   onClickImage,
 }) => {
+  const imageWidth = useMemo(() => window.innerWidth * 0.18, []);
+
   return (
     <div className={`image-slide ${direction} ${paused ? 'pause' : ''}`}>
       {imgSrcs.map((src, idx) => (
@@ -23,7 +25,7 @@ const ImageSlider: FunctionComponent<Props> = ({
           className="image-slide-element"
           src={src}
           alt={`이미지 슬라이드 ${idx + 1}번째`}
-          width={400}
+          width={imageWidth}
           onClick={() => onClickImage(src)}
         />
       ))}
@@ -34,7 +36,7 @@ const ImageSlider: FunctionComponent<Props> = ({
             className="image-slide-element"
             src={src}
             alt={`이미지 슬라이드 ${idx + 1}번째`}
-            width={400}
+            width={imageWidth}
             onClick={() => onClickImage(src)}
           />
         ))}

--- a/src/features/detail/components/ImageSlider.tsx
+++ b/src/features/detail/components/ImageSlider.tsx
@@ -23,6 +23,7 @@ const ImageSlider: FunctionComponent<Props> = ({
           className="image-slide-element"
           src={src}
           alt={`이미지 슬라이드 ${idx + 1}번째`}
+          width={400}
           onClick={() => onClickImage(src)}
         />
       ))}
@@ -33,6 +34,7 @@ const ImageSlider: FunctionComponent<Props> = ({
             className="image-slide-element"
             src={src}
             alt={`이미지 슬라이드 ${idx + 1}번째`}
+            width={400}
             onClick={() => onClickImage(src)}
           />
         ))}

--- a/src/features/landing/components/ImageSlide.tsx
+++ b/src/features/landing/components/ImageSlide.tsx
@@ -17,7 +17,11 @@ const ImageSlide: FunctionComponent<Props> = ({
 }) => {
   const ref = useRef<HTMLCanvasElement>(null);
   const { data: images } = usePromises<HTMLImageElement>(
-    imageSlideElementList.map((imageId) => fetchImage(getFullImgUrl(imageId))),
+    imageSlideElementList.map((imageId) =>
+      fetchImage(getFullImgUrl(imageId), {
+        w: 1000,
+      }),
+    ),
   );
 
   useEffect(() => {

--- a/src/features/landing/helper.ts
+++ b/src/features/landing/helper.ts
@@ -5,11 +5,14 @@ import {
   IMAGE_STAY_TERM,
 } from '~/features/landing/constants';
 import { CanvasSize } from '~/features/landing/types';
+import { getUrlWithParam } from '~/features/shared/utils/url';
 
-export const fetchImage = (src: string) => {
+type ImageOption = { w?: number; h?: number; q?: number };
+
+export const fetchImage = (src: string, options: ImageOption = {}) => {
   return new Promise<HTMLImageElement>((resolve, reject) => {
     const img = new Image();
-    img.src = src;
+    img.src = getUrlWithParam(src, { ...options, fm: 'webp' });
     img.onload = () => resolve(img);
     img.onerror = () => reject(new Error('image load error'));
   });

--- a/src/features/shared/components/Image/index.tsx
+++ b/src/features/shared/components/Image/index.tsx
@@ -2,14 +2,26 @@ import { forwardRef, LegacyRef } from 'react';
 
 import '~/style/index.scss';
 import { ImgProps } from '~/types';
-import { getUrlWithParam } from '~/features/shared/utils/url';
+import {
+  getImageUrlWithCdn,
+  getUrlWithParam,
+} from '~/features/shared/utils/url';
 
-type Props = ImgProps & { onClick?: () => void };
+type Props = ImgProps & {
+  onClick?: () => void;
+  options?: Record<string, string | number | undefined>;
+};
 
 const Image = (props: Props, ref: LegacyRef<HTMLImageElement> | null) => {
-  const { src, alt, width, height, className, style, onClick } = props;
+  const { src, alt, width, height, className, style, onClick, options } = props;
   const aspectRatio = width && height ? width / height : 0;
-  const srcWithSize = getUrlWithParam(src, { w: width, h: height, fm: 'webp' });
+  const srcWithCdn = getImageUrlWithCdn(src);
+  const srcWithSize = getUrlWithParam(srcWithCdn, {
+    ...options,
+    w: width,
+    h: height,
+    fm: 'webp',
+  });
   return (
     <img
       {...{ className, alt, width, height, ref }}

--- a/src/features/shared/components/Image/index.tsx
+++ b/src/features/shared/components/Image/index.tsx
@@ -2,13 +2,14 @@ import { forwardRef, LegacyRef } from 'react';
 
 import '~/style/index.scss';
 import { ImgProps } from '~/types';
+import { getUrlWithParam } from '~/features/shared/utils/url';
 
 type Props = ImgProps & { onClick?: () => void };
 
 const Image = (props: Props, ref: LegacyRef<HTMLImageElement> | null) => {
   const { src, alt, width, height, className, style, onClick } = props;
   const aspectRatio = width && height ? width / height : 0;
-  const srcWithSize = `${src}?w=${width}&h=${height}`;
+  const srcWithSize = getUrlWithParam(src, { w: width, h: height, fm: 'webp' });
   return (
     <img
       {...{ className, alt, width, height, ref }}

--- a/src/features/shared/utils/url.ts
+++ b/src/features/shared/utils/url.ts
@@ -1,0 +1,10 @@
+export const getUrlWithParam = (
+  url: string,
+  param: Record<string, string | number | undefined>,
+): string => {
+  const query = Object.entries(param)
+    .filter(([_, value]) => value !== undefined)
+    .map(([key, value]) => `${key}=${value}`)
+    .join('&');
+  return url + (query ? `?${query}` : '');
+};

--- a/src/features/shared/utils/url.ts
+++ b/src/features/shared/utils/url.ts
@@ -1,3 +1,8 @@
+import {
+  PHOTO_PATH_PREFIX,
+  PREV_PHOTO_PATH_PREFIX,
+} from '~/features/shared/constants';
+
 export const getUrlWithParam = (
   url: string,
   param: Record<string, string | number | undefined>,
@@ -7,4 +12,10 @@ export const getUrlWithParam = (
     .map(([key, value]) => `${key}=${value}`)
     .join('&');
   return url + (query ? `?${query}` : '');
+};
+
+export const getImageUrlWithCdn = (src: string): string => {
+  return src.startsWith(PHOTO_PATH_PREFIX)
+    ? src
+    : PHOTO_PATH_PREFIX + src.split(PREV_PHOTO_PATH_PREFIX)[1];
 };


### PR DESCRIPTION
## 🤩 개요
이미지 리소스 사이즈 줄이기,  라이트하우스 점수 개선

## 🧑‍💻 작업 사항
- 기존에 webp 포맷 사용하지 않고 있었음. cdn 옵션에 webp 추가
- cdn 경로 사용하지 않는 이미지가 다수 있었음. Image 컴포넌트 사용할 경우, 기존 사용하던 `https://raw.githubusercontent.com/` 주소의 이미지일 경우 cdn 경로 사용하도록 변경함.
- dailybook과 about 프로필 등 항상 크롭된 사이즈를 사용하는 경우, cdn의 fit=crop 옵션 사용하도록 함
- w, h 설정 없던 이미지에 적당한 사이즈 설정
- 기타 라이트하우스 관련 작업
  - aspectRatio 관련 경고가 있어 width, height으로 계산된 값 사용하게 변경함 @kingyong9169 
  - description meta 태그 추가함

## 📖 참고 사항

아래 비교는 로컬 기준 / 캐시비우기&강력새로고침 / (네트워크) 메인 페이지 처음부터 끝까지 스크롤 했을 때 기준

| 구분 | 네트워크 | 라이트하우스 |
|:--:|:----:|:-----:|
|as-is|![image](https://user-images.githubusercontent.com/40057032/224069952-6aa3830f-5e9d-4a6e-8f8a-39106608f28f.png) 이미지 총 크기 13MB|![스크린샷 2023-03-10 오전 12 23 31](https://user-images.githubusercontent.com/40057032/224070674-c727bdb6-7b8d-4c44-89fb-56bb9532e8b9.png)|
|to-be|![image](https://user-images.githubusercontent.com/40057032/224069968-04bac4bb-93bb-4e07-96fe-3c91613aef72.png) 이미지 총 크기 5.9MB (45%)|![스크린샷 2023-03-10 오전 12 22 56](https://user-images.githubusercontent.com/40057032/224070486-b9907302-e468-4cad-a2b1-0c680312d798.png)|
